### PR TITLE
Bux fix

### DIFF
--- a/torchmin/minimize_constr.py
+++ b/torchmin/minimize_constr.py
@@ -195,8 +195,8 @@ def minimize_constr(
     # handle callbacks
     if callback is not None:
         callback_ = callback
-        callback = lambda x: callback_(
-            torch.tensor(x, dtype=x0.dtype, device=x0.device).view_as(x0))
+        callback = lambda x, state: callback_(
+            torch.tensor(x, dtype=x0.dtype, device=x0.device).view_as(x0), state)
 
     # handle bounds
     if bounds is not None:


### PR DESCRIPTION
According to the [scipy docs](https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html), the method ‘trust-constr’ requires different callback signature. Hence, supplying 'minimize_constr' with a callback raised an error before this bug fix.