### PR TITLE
Trustregion-exact triangular solver update

### DIFF
--- a/torchmin/trustregion/exact.py
+++ b/torchmin/trustregion/exact.py
@@ -64,7 +64,7 @@ def _minimize_trust_exact(fun, x0, **trust_region_options):
 
 
 def solve_triangular(A, b, **kwargs):
-    return torch.triangular_solve(b.unsqueeze(1), A, **kwargs)[0].squeeze(1)
+    return torch.linalg.solve_triangular(A, b.unsqueeze(1), **kwargs)[0].squeeze(1)
 
 
 def solve_cholesky(A, b, **kwargs):


### PR DESCRIPTION
Updated '.../torchmin/trustregion/exact.py:67' to resolve the following warning:

"UserWarning: torch.triangular_solve is deprecated in favor of torch.linalg.solve_triangularand will be removed in a future PyTorch release. torch.linalg.solve_triangular has its arguments reversed and does not return a copy of one of the inputs. X = torch.triangular_solve(B, A).solution
should be replaced with
X = torch.linalg.solve_triangular(A, B)."