### PR TITLE
Use an eventual return from the optional callback to stop the minimization

### DIFF
--- a/torchmin/bfgs.py
+++ b/torchmin/bfgs.py
@@ -226,7 +226,11 @@ def _minimize_bfgs_core(
         if return_all:
             allvecs.append(x_new)
         if callback is not None:
-            callback(x_new)
+            if callback(x_new):
+                warnflag = 1
+                msg = 'Stopped by the user through the callback function.'
+                break
+
 
         # ================================
         #   update hessian approximation

--- a/torchmin/cg.py
+++ b/torchmin/cg.py
@@ -119,7 +119,10 @@ def _minimize_cg(fun, x0, max_iter=None, gtol=1e-5, normp=float('inf'),
         if return_all:
             allvecs.append(x)
         if callback is not None:
-            callback(x)
+            if callback(x):
+                warnflag = 1
+                msg = 'Stopped by the user through the callback function.'
+                break
 
         # check optimality
         if grad_norm <= gtol:

--- a/torchmin/newton.py
+++ b/torchmin/newton.py
@@ -184,7 +184,10 @@ def _minimize_newton_cg(
         if disp > 1:
             print('iter %3d - fval: %0.4f' % (n_iter, f))
         if callback is not None:
-            callback(x)
+            if callback(x):
+                warnflag = 1
+                msg = 'Stopped by the user through the callback function.'
+                break
         if return_all:
             allvecs.append(x)
 
@@ -369,7 +372,10 @@ def _minimize_newton_exact(
         if disp > 1:
             print('iter %3d - fval: %0.4f - info: %d' % (n_iter, f, info))
         if callback is not None:
-            callback(x)
+            if callback(x):
+                warnflag = 1
+                msg = 'Stopped by the user through the callback function.'
+                break
         if return_all:
             allvecs.append(x)
 

--- a/torchmin/trustregion/base.py
+++ b/torchmin/trustregion/base.py
@@ -234,7 +234,10 @@ def _minimize_trust_region(fun, x0, subproblem=None, initial_trust_radius=1.,
         if return_all:
             allvecs.append(x.clone())
         if callback is not None:
-            callback(x.clone())
+            if callback(x.clone()):
+                warnflag = 1
+                msg = 'Stopped by the user through the callback function.'
+                break
         k += 1
 
         # verbosity check


### PR DESCRIPTION
Hi

I started to use your package to optimize a problem related to image formation in optics. I found it worked great but there is one issue related to the fact one cannot stop the loop when wanted. 

In general in a script you don't have anyway a mean to stop except by force breaking. However I'm building a user interface around my problem and the user can start/stop the algorithm using some actions/buttons. My program is implementing many different algorithm where stopping anytime is feasible but the use of the minimize function prevent this action until tolerance or max_iter are triggered.

In this PR, I'm using the only place where one can insert some control of the inner minimize for loop, that is through the call of the callback. I'm using it to update some plots and I figured a return value could trigger a break of the inner loop. I just implemented it and it's simple yet works great. What do you think? It doesn't change the base implementation, the user will just break the loop if the callback returns True while usually it return None.

I thought maybe the use of the Minimizer object could allow me to do so (stopping whenever I want) as one control the optimization step. But my attempt showed this implementation is much slower than the usage of the minimize method... hence this PR
